### PR TITLE
Ignore .import files temporarily

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .godot/
 .nomedia
 
+*.import
 .import/
 export.cfg
 export_presets.cfg


### PR DESCRIPTION
> Closes #2 

## Description
Currently .import files are acting weird. They update seemingly after any command, making committing them unfeasible, they can't be removed with `git restore` and even deleting them makes them show up instantly, without Godot being opened(?). This PR aims to remedy this temporarily, until there's further light on whatever's going on.

TLDR; Adds .import to gitignore temporarily